### PR TITLE
add global ll alias to bash image

### DIFF
--- a/images/bash/build.sh
+++ b/images/bash/build.sh
@@ -23,4 +23,6 @@ finish_rootfs_build()
     # busybox's grep doesn't support --colour=auto args, add a check for the alias in bashrc
     sed-or-die 'alias grep=' 'grep --colour=auto root /etc/group \&> /dev/null \&\& alias grep=' \
         "${_EMERGE_ROOT}"/etc/bash/bashrc
+    # add ll global alias
+    echo "alias ll='ls -lah --group-directories-first'" >> "${_EMERGE_ROOT}"/etc/bash/bashrc
 }


### PR DESCRIPTION
I was missing the `ll` alias and thought it might be useful to add it as a global alias to the bash image instead of doing it somewhere else.