### PR TITLE
remove keywording dev-python/ssl-fetch from builders

### DIFF
--- a/builder/bob-musl/build.sh
+++ b/builder/bob-musl/build.sh
@@ -34,7 +34,6 @@ configure_bob() {
     update_use 'app-crypt/pinentry' '+ncurses'
     update_use 'dev-libs/libpcre2' '+jit'
     update_keywords 'app-portage/layman' '+~amd64'
-    update_keywords 'dev-python/ssl-fetch' '+~amd64'
     update_keywords 'app-admin/su-exec' '+~amd64'
     emerge dev-vcs/git app-portage/layman app-misc/jq app-shells/bash-completion
     install_git_postsync_hooks

--- a/builder/bob-uclibc/build.sh
+++ b/builder/bob-uclibc/build.sh
@@ -29,7 +29,6 @@ configure_bob() {
     update_use 'dev-vcs/git' '-perl'
     update_use 'app-crypt/pinentry' '+ncurses'
     update_keywords 'app-portage/layman' '+~amd64'
-    update_keywords 'dev-python/ssl-fetch' '+~amd64'
     update_keywords 'app-admin/su-exec' '+~amd64'
     emerge dev-vcs/git app-portage/layman app-misc/jq app-shells/bash-completion
     install_git_postsync_hooks

--- a/builder/bob/build.sh
+++ b/builder/bob/build.sh
@@ -29,7 +29,6 @@ configure_bob() {
     update_use 'dev-vcs/git' '-perl'
     update_use 'app-crypt/pinentry' '+ncurses'
     update_keywords 'app-portage/layman' '+~amd64'
-    update_keywords 'dev-python/ssl-fetch' '+~amd64'
     update_keywords 'app-admin/su-exec' '+~amd64'
     emerge dev-vcs/git app-portage/layman app-misc/jq app-shells/bash-completion
     install_git_postsync_hooks


### PR DESCRIPTION
There is no unstable version anymore and having it in the builders will break building them.