### PR TITLE
Fix busybox libxcrypt USE static-libs

### DIFF
--- a/images/busybox/build.sh
+++ b/images/busybox/build.sh
@@ -10,6 +10,7 @@ configure_rootfs_build()
 {
     update_use 'sys-apps/busybox' +make-symlinks +static
     update_use 'virtual/libcrypt' +static-libs
+    update_use 'sys-libs/libxcrypt' +static-libs
     update_use 'sys-apps/sed' +static -acl -nls
     # bug in busybox-1.31.1-r2 ebuild, musl is pulled in as rdep but we build static version
     provide_package sys-libs/musl


### PR DESCRIPTION
- With portage-20230418 and stage3-amd64-musl-hardened-20230416T164657Z would get emerge error:

```
emerge: there are no ebuilds built with USE flags to satisfy "sys-libs/libxcrypt[system(-),static-libs(-)?]".
!!! One of the following packages is required to complete your request:
- sys-libs/libxcrypt-4.4.33::gentoo (Change USE: +static-libs)
- virtual/libcrypt-2-r1::gentoo (Change USE: -static-libs)
(dependency required by "virtual/libcrypt-2-r1::gentoo" [ebuild])
(dependency required by "sys-apps/busybox-1.34.1-r1::gentoo[static]" [ebuild])
(dependency required by "sys-apps/busybox" [argument])
```

I tried this with a clean build, with no cached binary packages, and hit the above emerge error.