### PR TITLE
OpenSSL USE bindist dropped

### DIFF
--- a/builder/bob-musl/build.sh
+++ b/builder/bob-musl/build.sh
@@ -26,10 +26,6 @@ configure_bob() {
     # install default packages
     # when using overlay1 docker storage the created hard link will trigger an error during openssh uninstall
     [[ -f /usr/"${_LIB}"/misc/ssh-keysign ]] && rm /usr/"${_LIB}"/misc/ssh-keysign
-    emerge -C net-misc/openssh dev-libs/openssl
-    update_use 'dev-libs/openssl' -bindist
-    emerge net-misc/openssh
-    emerge @preserved-rebuild
     update_use 'dev-vcs/git' '-perl'
     update_use 'app-crypt/pinentry' '+ncurses'
     update_use 'dev-libs/libpcre2' '+jit'

--- a/builder/bob/build.sh
+++ b/builder/bob/build.sh
@@ -22,10 +22,6 @@ configure_bob() {
     # install default packages
     # when using overlay1 docker storage the created hard link will trigger an error during openssh uninstall
     [[ -f /usr/"${_LIB}"/misc/ssh-keysign ]] && rm /usr/"${_LIB}"/misc/ssh-keysign
-    emerge -C net-misc/openssh dev-libs/openssl
-    update_use 'dev-libs/openssl' -bindist
-    emerge net-misc/openssh
-    emerge @preserved-rebuild
     update_use 'dev-vcs/git' '-perl'
     update_use 'app-crypt/pinentry' '+ncurses'
     update_keywords 'app-admin/su-exec' '+~amd64'


### PR DESCRIPTION
- Gentoo dropped USE bindist from openssl https://www.gentoo.org/support/news-items/2021-10-17-openssl-bindist-removal.html
- So, no need to remove openssh, set `-bindist` USE flag, and re-emerge, as there is no such USE flag, and the re-emerging is unneccesary.