### PR TITLE
[python3] Fix missing GCC libraries

### DIFF
--- a/images/python3/build.sh
+++ b/images/python3/build.sh
@@ -28,5 +28,6 @@ configure_rootfs_build()
 #
 finish_rootfs_build()
 {
-    :
+    # required for internal modules
+    copy_gcc_libs
 }


### PR DESCRIPTION
As discussed in #9 this fixes missing GCC libraries for internal Python modules.