### PR TITLE
Fix Dockerfile syntax

### DIFF
--- a/images/glibc/Dockerfile.template
+++ b/images/glibc/Dockerfile.template
@@ -1,7 +1,7 @@
 FROM ${IMAGE_PARENT}
 LABEL maintainer="${MAINTAINER}"
 
-ENV LANG en_US.utf8
+ENV LANG=en_US.utf8
 
 ADD rootfs.tar /
 

--- a/images/lynx/Dockerfile.template
+++ b/images/lynx/Dockerfile.template
@@ -1,11 +1,11 @@
 FROM ${IMAGE_PARENT}
-MAINTAINER ${MAINTAINER}
+LABEL maintainer="${MAINTAINER}"
 
 ADD rootfs.tar /
 
 # User setup
 USER user
-ENV HOME /home/user
+ENV HOME=/home/user
 WORKDIR $HOME
 
 ENTRYPOINT [ "lynx" ]

--- a/images/musl/Dockerfile.template
+++ b/images/musl/Dockerfile.template
@@ -1,6 +1,6 @@
 FROM ${IMAGE_PARENT}
-MAINTAINER ${MAINTAINER}
+LABEL maintainer="${MAINTAINER}"
 
-#ENV LANG en_US.utf8
+#ENV LANG=en_US.utf8
 
 ADD rootfs.tar /

--- a/images/nginx/Dockerfile.template
+++ b/images/nginx/Dockerfile.template
@@ -5,7 +5,7 @@ ADD rootfs.tar /
 
 COPY etc /etc
 
-ENV NG_TMPL_DEFAULT_ROOT /var/www/localhost
+ENV NG_TMPL_DEFAULT_ROOT=/var/www/localhost
 
 RUN chmod +x $(find /etc/service -name run) && \
     ln -s /etc/s6_finish_default /etc/service/nginx/finish && \

--- a/images/nodejs/Dockerfile.template
+++ b/images/nodejs/Dockerfile.template
@@ -9,7 +9,7 @@ ONBUILD RUN if [ -n "${NODEJS_UID}" ] && [ -n "${NODEJS_GID}" ]; then \
               sed-or-die '^nodejs:x:[0-9]*:' "nodejs:x:${NODEJS_GID}:" /etc/group; \
               chown -R nodejs:nodejs /home/nodejs ; fi
 
-ENV PATH "${PATH}:/usr/local/yarn/bin"
+ENV PATH="${PATH}:/usr/local/yarn/bin"
 
 ADD rootfs.tar /
 

--- a/images/openssl-musl/Dockerfile.template
+++ b/images/openssl-musl/Dockerfile.template
@@ -1,4 +1,4 @@
 FROM ${NAMESPACE}/musl
-MAINTAINER ${MAINTAINER}
+LABEL maintainer="${MAINTAINER}"
 
 ADD rootfs.tar /


### PR DESCRIPTION
- `ENV` and `LABEL` directives should use `=` (instead of a space).
- `MAINTAINER` directive is deprecated, use `LABEL maintainer=`.

This silences docker build warnings, like:

```
 1 warning found (use docker --debug to expand):
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 4)
```