### PR TITLE
eliminate EAPI=6 ebuilds from musl-overlay

### DIFF
--- a/builder/bob-musl/build.sh
+++ b/builder/bob-musl/build.sh
@@ -17,8 +17,7 @@ configure_bob() {
     eselect news read new 1> /dev/null
     # use hot fix in 0.99.4
     echo '=app-portage/flaggie-0.99.4 ~amd64' >> /etc/portage/package.accept_keywords/flaggie
-    emerge app-portage/flaggie app-portage/eix app-portage/gentoolkit
-    eix-update
+    emerge app-portage/flaggie app-portage/gentoolkit
     touch /etc/portage/package.accept_keywords/flaggie
     echo 'LANG="en_US.utf8"' > /etc/env.d/02locale
     env-update
@@ -35,5 +34,8 @@ configure_bob() {
     [[ "${BOB_UPDATE_WORLD}" == true ]] && emerge -vuND world
     add_overlay musl
     add_overlay kubler https://github.com/edannenberg/kubler-overlay.git
+    find /var/db/repos/musl -name '*.ebuild' | xargs egrep -l EAPI=[123456] | xargs rm
+    emerge app-portage/eix
+    eix-update
     emerge dev-lang/go
 }


### PR DESCRIPTION
musl-overlay has some EAPI=6 ebuild, which breaks eix-update, even if those builds are not emerged.
This "hack" defers the app-portage/eix emerge until after EAPI=6 ebuilds have been deleted from the musl-overlay working-area.