### PR TITLE
Update bob-musl/build.conf

### DIFF
--- a/builder/bob-musl/build.conf
+++ b/builder/bob-musl/build.conf
@@ -2,7 +2,7 @@
 #BUILDER="${NAMESPACE}/foo"
 
 # ..or bootstrap a fresh stage3, overrides BUILDER if defined
-STAGE3_BASE='stage3-amd64-musl-hardened'
+STAGE3_BASE='stage3-amd64-musl-hardened-openrc'
 STAGE3_DATE='20250427T155021Z'
 #ARCH='amd64'
 #ARCH_URL="${MIRROR}releases/${ARCH}/autobuilds/current-${STAGE3_BASE}/"


### PR DESCRIPTION
The base stage was renamed from `stage3-amd64-musl-hardened` to `stage3-amd64-musl-hardened-openrc`. Apparently.